### PR TITLE
Fixes a.sc's kerning class

### DIFF
--- a/sources/Baskervville.glyphs
+++ b/sources/Baskervville.glyphs
@@ -21324,7 +21324,7 @@ width = 558;
 {
 color = 6;
 glyphname = a.sc;
-kernLeft = t;
+kernLeft = a.sc;
 kernRight = a.sc;
 lastChange = "2025-03-13 17:52:25 +0000";
 layers = (


### PR DESCRIPTION
See https://github.com/anrt-type/ANRT-Baskervville/issues/11

This proposed change moves a.sc into the correct right-side kerning class (currently, it's in `t`'s).